### PR TITLE
Update default config

### DIFF
--- a/src/main/java/sawfowl/commandsyncclient/bukkit/CSC.java
+++ b/src/main/java/sawfowl/commandsyncclient/bukkit/CSC.java
@@ -71,7 +71,7 @@ public class CSC extends JavaPlugin {
 
 	public String[] loadConfig() {
 		String[] defaults = new String[] {
-			"ip=localhost", "port=39999", "heartbeat=1000", "name=UNSET", "pass=UNSET", "debug=false", "removedata=false", "lang=en_US"
+			"ip=YOUR_PROXY_ADDRESS", "port=39999", "heartbeat=1000", "name=UNSET", "pass=UNSET", "debug=false", "removedata=false", "lang=en_US"
 		};
 		String[] data = new String[defaults.length];
 		try {

--- a/src/main/java/sawfowl/commandsyncclient/sponge/CSC.java
+++ b/src/main/java/sawfowl/commandsyncclient/sponge/CSC.java
@@ -93,7 +93,7 @@ public class CSC {
 
 	private String[] loadConfig() {
 		String[] defaults = new String[] {
-			"ip=localhost", "port=39999", "heartbeat=1000", "name=UNSET", "pass=UNSET", "debug=false", "removedata=false", "lang=en_US"
+			"ip=YOUR_PROXY_ADDRESS", "port=39999", "heartbeat=1000", "name=UNSET", "pass=UNSET", "debug=false", "removedata=false", "lang=en_US"
 		};
 		String[] data = new String[defaults.length];
 		try {

--- a/src/main/java/sawfowl/commandsyncserver/bungee/CSS.java
+++ b/src/main/java/sawfowl/commandsyncserver/bungee/CSS.java
@@ -112,7 +112,7 @@ public class CSS extends Plugin {
 	
 	private String[] loadConfig() {
 		String[] defaults = new String[] {
-			"ip=localhost", "port=39999", "heartbeat=1000", "pass=UNSET", "debug=false", "removedata=false", "lang=en_US"
+			"ip=0.0.0.0", "port=39999", "heartbeat=1000", "pass=UNSET", "debug=false", "removedata=false", "lang=en_US"
 		};
 		String[] data = new String[defaults.length];
 		try {

--- a/src/main/java/sawfowl/commandsyncserver/velocity/CSS.java
+++ b/src/main/java/sawfowl/commandsyncserver/velocity/CSS.java
@@ -147,7 +147,7 @@ public class CSS {
 	
 	private String[] loadConfig() {
 		String[] defaults = new String[] {
-			"ip=localhost", "port=39999", "heartbeat=1000", "pass=UNSET", "debug=false", "removedata=false", "lang=en_US"
+			"ip=0.0.0.0", "port=39999", "heartbeat=1000", "pass=UNSET", "debug=false", "removedata=false", "lang=en_US"
 		};
 		String[] data = new String[defaults.length];
 		try {


### PR DESCRIPTION
The default config for both the proxy and backend servers is set to "localhost" which will not work. The proxy must be set to "0.0.0.0" and the backend servers must have the same IP/server address as the velocity proxy. This pull request changes the default config to set the IP to "0.0.0.0" on a Bungee/Velocity proxy, and changes localhost to "YOUR_PROXY_ADDRESS" on Bukkit/Sponge servers.