### PR TITLE
Specify API Version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 ## Version
 major=2
 minor=8
-patch=3
+patch=5
 suffix=RELEASE
 api=10.0.0
 ## Dependencies

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,7 @@
 name: CommandSync
 main: sawfowl.commandsyncclient.bukkit.CSC
-version: 2.8.3
+version: 2.8.5
+api-version: 1.13
 author: YoFuzzy3
 description: Synchronize commands across servers.
 


### PR DESCRIPTION
Properly updated the plugin version and specified an api-version to fix this when using newer server versions.

[Server thread/WARN]: [org.bukkit.craftbukkit.legacy.CraftLegacy] Initializing Legacy Material Support. Unless you have legacy plugins and/or data this is a bug!
[Server thread/WARN]: Legacy plugin CommandSync v2.8.3 does not specify an api-version.